### PR TITLE
refactoring email service

### DIFF
--- a/src/main/java/br/edu/ifce/matheus/pacc/adapters/email/EmailServiceImpl.java
+++ b/src/main/java/br/edu/ifce/matheus/pacc/adapters/email/EmailServiceImpl.java
@@ -1,7 +1,7 @@
 package br.edu.ifce.matheus.pacc.adapters.email;
 
 import br.edu.ifce.matheus.pacc.domain.exceptions.EmailSenderException;
-import br.edu.ifce.matheus.pacc.domain.ports.driven.EmailSender;
+import br.edu.ifce.matheus.pacc.domain.ports.driven.EmailService;
 import lombok.AllArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -15,25 +15,27 @@ import javax.mail.internet.MimeMessage;
 
 @Service
 @AllArgsConstructor
-public class EmailSenderImpl implements EmailSender {
+public class EmailServiceImpl implements EmailService {
 
     private final static String EMAIL_FROM = "no-reply@pacc.com";
-    private final static Logger LOGGER = LoggerFactory.getLogger(EmailSenderImpl.class);
+    private final static Logger LOGGER = LoggerFactory.getLogger(EmailServiceImpl.class);
 
     private final JavaMailSender javaMailSender;
 
     @Override
     @Async
-    public void execute(String recipient, String confirmationLink, String token) {
-        String link = confirmationLink + token;
-        String emailBody = buildEmail(recipient, link);
+    public void execute(EmailDetails details) {
+        String link = details.getConfirmationLink();
+        String name = details.getUserFirstName();
+        String to = details.getTo();
+        String emailBody = buildEmail(name, link);
 
         try {
             MimeMessage mimeMessage = javaMailSender.createMimeMessage();
             MimeMessageHelper helper = new MimeMessageHelper(mimeMessage, "utf-8");
 
             helper.setText(emailBody, true);
-            helper.setTo(recipient);
+            helper.setTo(to);
             helper.setSubject("Confirm your email");
             helper.setFrom(EMAIL_FROM);
 

--- a/src/main/java/br/edu/ifce/matheus/pacc/domain/ports/driven/EmailSender.java
+++ b/src/main/java/br/edu/ifce/matheus/pacc/domain/ports/driven/EmailSender.java
@@ -1,5 +1,0 @@
-package br.edu.ifce.matheus.pacc.domain.ports.driven;
-
-public interface EmailSender {
-    void execute(String recipient, String confirmationLink, String token);
-}

--- a/src/main/java/br/edu/ifce/matheus/pacc/domain/ports/driven/EmailService.java
+++ b/src/main/java/br/edu/ifce/matheus/pacc/domain/ports/driven/EmailService.java
@@ -1,0 +1,16 @@
+package br.edu.ifce.matheus.pacc.domain.ports.driven;
+
+import lombok.Getter;
+import lombok.Setter;
+
+public interface EmailService {
+    void execute(EmailDetails details);
+
+    @Getter
+    @Setter
+    class EmailDetails {
+        private String to;
+        private String userFirstName;
+        private String confirmationLink;
+    }
+}

--- a/src/main/java/br/edu/ifce/matheus/pacc/domain/ports/driver/SendConfirmationEmail.java
+++ b/src/main/java/br/edu/ifce/matheus/pacc/domain/ports/driver/SendConfirmationEmail.java
@@ -1,0 +1,7 @@
+package br.edu.ifce.matheus.pacc.domain.ports.driver;
+
+import br.edu.ifce.matheus.pacc.domain.entities.User;
+
+public interface SendConfirmationEmail {
+    void execute(User user, String confirmationLink);
+}

--- a/src/main/java/br/edu/ifce/matheus/pacc/domain/services/RegisterNewUserAndSendConfirmationLinkService.java
+++ b/src/main/java/br/edu/ifce/matheus/pacc/domain/services/RegisterNewUserAndSendConfirmationLinkService.java
@@ -5,10 +5,10 @@ import br.edu.ifce.matheus.pacc.domain.entities.User;
 import br.edu.ifce.matheus.pacc.domain.entities.enums.UserRole;
 import br.edu.ifce.matheus.pacc.domain.exceptions.InvalidEmailException;
 import br.edu.ifce.matheus.pacc.domain.exceptions.UserExistsException;
-import br.edu.ifce.matheus.pacc.domain.ports.driven.EmailSender;
 import br.edu.ifce.matheus.pacc.domain.ports.driven.PasswordEncoder;
 import br.edu.ifce.matheus.pacc.domain.ports.driven.UserRepository;
 import br.edu.ifce.matheus.pacc.domain.ports.driver.RegisterNewUserAndSendConfirmationLink;
+import br.edu.ifce.matheus.pacc.domain.ports.driver.SendConfirmationEmail;
 import br.edu.ifce.matheus.pacc.domain.services.utils.EmailValidation;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -24,7 +24,7 @@ public class RegisterNewUserAndSendConfirmationLinkService implements RegisterNe
 
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
-    private final EmailSender emailSender;
+    private final SendConfirmationEmail sendConfirmationEmail;
 
     @Override
     public String execute(User user, String confirmationLink) {
@@ -48,7 +48,7 @@ public class RegisterNewUserAndSendConfirmationLinkService implements RegisterNe
 
         userRepository.saveUser(user);
 
-        emailSender.execute(user.getEmail(), confirmationLink, token);
+        sendConfirmationEmail.execute(user, confirmationLink);
 
         return "confirm your email";
     }

--- a/src/main/java/br/edu/ifce/matheus/pacc/domain/services/SendConfirmationEmailService.java
+++ b/src/main/java/br/edu/ifce/matheus/pacc/domain/services/SendConfirmationEmailService.java
@@ -1,0 +1,29 @@
+package br.edu.ifce.matheus.pacc.domain.services;
+
+import br.edu.ifce.matheus.pacc.domain.entities.User;
+import br.edu.ifce.matheus.pacc.domain.ports.driven.EmailService;
+import br.edu.ifce.matheus.pacc.domain.ports.driver.SendConfirmationEmail;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@AllArgsConstructor
+public class SendConfirmationEmailService implements SendConfirmationEmail {
+
+    private final EmailService emailService;
+
+    @Override
+    public void execute(User user, String confirmationLink) {
+        var userName = user.getFirstName();
+        var userEmail = user.getEmail();
+        var userToken = user.getConfirmationToken().getToken();
+
+        var details = new EmailService.EmailDetails();
+
+        details.setTo(userEmail);
+        details.setUserFirstName(userName);
+        details.setConfirmationLink(confirmationLink + userToken);
+
+        emailService.execute(details);
+    }
+}


### PR DESCRIPTION
- Renaming EmailSender to EmailService
- Defining a data holder class in EmailService
- EmailServiceImpl now sends the user name in the html body
- Implementing a new SendConfirmationEmail interface
- SendEmailConfirmationService is now responsible for using the EmailService interface